### PR TITLE
Changed team page link on homepage to current repo

### DIFF
--- a/source/home-page/index.html
+++ b/source/home-page/index.html
@@ -26,7 +26,7 @@
       <aside class="subtitle">
         Brought to you by
         <a
-          href="https://github.com/cse110-sp23-group20/cse110-sp23-group20/blob/main/admin/team.md"
+          href="https://github.com/cse110-sp23-group20/fortune-teller/blob/main/admin/team.md"
           class="team-link hover-underline"
           >20/20 Visionaries</a
         >


### PR DESCRIPTION
Feel like its better to link to current repo than the old one since the old one isn't being updated